### PR TITLE
MakeDoubleTurns modifiers instead of Turns

### DIFF
--- a/Code/cubeTurns.py
+++ b/Code/cubeTurns.py
@@ -5,22 +5,18 @@
 x2 = [
 
     "R",
-    "R2",
     "L",
-    "L2",
     "U",
-    "U2",
     "D",
-    "D2",
     "F",
-    "F2",
     "B",
-    "B2",
 
 ]
 
 
 modifiers = [
     " ", #Nothing
+    " ", #Nothing (for probability)
     "' ", #Prime
+    "2 ", #DoubleTurn
 ]


### PR DESCRIPTION
Making the `X2` moves an `X` with a modifier of `2` as opposed to an turn in the regular Turns list.